### PR TITLE
LoginPage, SignUpIndex 페이지 api연결

### DIFF
--- a/src/pages/login/LoginPage.jsx
+++ b/src/pages/login/LoginPage.jsx
@@ -17,11 +17,21 @@ const LoginPage = () => {
     mode: 'onBlur',
   });
 
+  const { mutate: postLogin } = usePostLogin();
+
   const onSubmit = async (data) => {
-    try {
-      // 여기에 API 연결하기
-      navigate(ROUTE_PATH.PROPOSAL);
-    } catch (error) {}
+    postLogin(
+      { email: data.email, password: data.password },
+      {
+        onSuccess: () => {
+          console.log('login success:', data);
+          navigate(ROUTE_PATH.PROPOSAL);
+        },
+        onError: (err) => {
+          console.error('login failed:', err);
+        },
+      },
+    );
   };
 
   return (

--- a/src/pages/signup/index.jsx
+++ b/src/pages/signup/index.jsx
@@ -1,5 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import useModeStore from '../../stores/useModeStore';
+import { usePostAccount } from '../../apis/accounts';
+import { useNavigate } from 'react-router-dom';
+import { ROUTE_PATH } from '../../constants/route';
 
 import SignUpPage1 from './SignUpPage1';
 import SignUpPage2 from './SignUpPage2';
@@ -10,30 +13,36 @@ import FounderTime from '../signup-founder/FounderTime';
 import WelcomePage from './WelcomePage';
 
 function SignUpIndex() {
+  const navigate = useNavigate();
   const { isProposerMode } = useModeStore(); // true=제안자, false=창업자
   const [currentStep, setCurrentStep] = useState(0);
-  const [signupData, setSignupData] = useState({}); //입력받은 데이터 저장하기
+  const [signupData, setSignupData] = useState({});
 
-  // 모드 바뀌면 단계 시퀀스 재생성
-  const steps = useMemo(() => {
-    return isProposerMode
-      ? [
-          SignUpPage1,
-          SignUpPage2,
-          OnBoardingSelect,
-          NeighborhoodSettingsPage,
-          WelcomePage, // 제안자는 여기서 끝
-        ]
-      : [
-          SignUpPage1,
-          SignUpPage2,
-          OnBoardingSelect,
-          NeighborhoodSettingsPage,
-          FounderTarget, // 창업자만
-          FounderTime, // 창업자만
-          WelcomePage,
-        ];
-  }, [isProposerMode]);
+  const { mutate: postAccount, isPending, isError, error } = usePostAccount();
+
+  const steps = useMemo(
+    () =>
+      isProposerMode
+        ? [
+            SignUpPage1,
+            SignUpPage2,
+            OnBoardingSelect,
+            NeighborhoodSettingsPage,
+            WelcomePage,
+          ]
+        : [
+            SignUpPage1,
+            SignUpPage2,
+            OnBoardingSelect,
+            NeighborhoodSettingsPage,
+            FounderTarget,
+            FounderTime,
+            WelcomePage,
+          ],
+    [isProposerMode],
+  );
+
+  const isLast = currentStep === steps.length - 1;
 
   const goToNextStep = (payload) => {
     if (payload && typeof payload === 'object') {
@@ -41,8 +50,61 @@ function SignUpIndex() {
     }
     setCurrentStep((prev) => Math.min(prev + 1, steps.length - 1));
   };
+
+  const buildPayload = () => {
+    const {
+      email,
+      password,
+      name,
+      birth,
+      sex,
+      is_marketing_allowed,
+      industryList,
+      addressList,
+      targetList,
+      business_hours,
+    } = signupData;
+
+    return {
+      email,
+      password,
+      name,
+      birth,
+      sex,
+      is_marketing_allowed: !!is_marketing_allowed,
+      industryList: industryList ?? [],
+      addressList: addressList ?? [],
+      targetList: targetList ?? null, // null이면 제안자
+      business_hours: business_hours ?? null, // null이면 제안자
+    };
+  };
+
+  const handleSubmit = () => {
+    if (isPending) return; // 중복 클릭 방지
+    const payload = buildPayload();
+
+    postAccount(payload, {
+      onSuccess: () => {
+        navigate(ROUTE_PATH.PROPOSAL);
+      },
+      onError: () => {},
+    });
+  };
+
   const Current = steps[currentStep];
-  return <Current onNextStep={goToNextStep} data={signupData} />;
+
+  return (
+    <Current
+      onNextStep={goToNextStep}
+      data={signupData}
+      onSubmit={isLast ? handleSubmit : undefined}
+      isSubmitting={isPending}
+      submitError={
+        isError ? error?.message || '회원가입에 실패했습니다.' : null
+      }
+      isLastStep={isLast}
+    />
+  );
 }
 
 export default SignUpIndex;


### PR DESCRIPTION
## 🔎 What is this PR?

- 퍼블리싱 관련 PR은 Figma GUI를 첨부해 주세요.

## ✨ Changes

- 마지막 스텝에서 usePostAccount로 가입 요청
- pages/signup/index.jsx에 회원가입 API 연동
- 스텝 수집 데이터 → buildPayload()로 변환
- 마지막 스텝(WelcomePage)에서 postAccount(payload, { onSuccess }) 호출
```const isLast = currentStep === steps.length - 1;```
- 성공 시 ROUTE_PATH.PROPOSAL로 이동

## 📷 Result

- 스크린샷, 시연 영상 등

## 💬 To. Reviewer

- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
